### PR TITLE
feat: t4 - get filename without the extension

### DIFF
--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Task 4 - get filename without the extension
+set -eo pipefail
+
+
+# Find only regular files and put in var
+files=$(find $1 -type f)
+
+
+# Then we cut off the paths and extensions.
+for file in $files; do
+  echo ${file%.*}
+done
+
+

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -4,6 +4,12 @@
 set -eo pipefail
 
 
+# args check
+if [ "$#" -ne 1 ]; then
+  echo "Specify a single directory."
+  exit 1
+fi
+
 # Find only regular files and put in array.
 files=$(find $1 -type f)
 

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# Task 4 - get filename without the extension
+# Task 4 - get filename without the extension.
 set -eo pipefail
 
 
-# Find only regular files and put in var
+# Find only regular files and put in array.
 files=$(find $1 -type f)
 
 

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -28,7 +28,10 @@ fi
 
 
 # Find only regular files and put in array.
-files=( $(find "$1" -type f) )
+files=()
+while IFS= read -r -d '' file; do
+  files+=("$file")
+done < <(find "$1" -type f -print0)
 
 
 # Then we cut off the paths and extensions.

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -10,6 +10,7 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
+
 # Find only regular files and put in array.
 files=$(find $1 -type f)
 
@@ -18,5 +19,3 @@ files=$(find $1 -type f)
 for file in $files; do
   echo ${file%.*}
 done
-
-

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -21,20 +21,9 @@ if [ "$#" -ne 1 ]; then
 fi
 
 
-# Directory exist check
-if [ ! -d "$1" ]; then
-  err  255 'Directory does not exist.'
-fi
-
-
-# Find only regular files and put in array.
-files=()
-while IFS= read -r -d '' file; do
-  files+=("$file")
-done < <(find "$1" -type f -print0)
-
-
-# Then we cut off the paths and extensions.
-for file in "${files[@]}"; do
-  echo "${file%%.*}"
+# Find all regular files in the directory and its subdirectories
+find "$1" -type f | while read file; do
+# Get the filename without the extension and keep the path
+  filename="${file##*/}"
+  echo "${file%/*}/${filename%%.*}"
 done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -15,7 +15,7 @@ err() {
 }
 
 
-# args check
+# Args check
 if [ "$#" -ne 1 ]; then
   err  255 'Specify a single directory.'
 fi

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -11,7 +11,7 @@ err() {
   local code="$1"
   shift
   echo "[[ERROR]: $(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
-  exit "$code"
+  exit "${code}"
 }
 
 

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -4,9 +4,14 @@
 set -eo pipefail
 
 
+err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+}
+
+
 # args check
 if [ "$#" -ne 1 ]; then
-  echo "Specify a single directory."
+  err "Specify a single directory."
   exit 1
 fi
 

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -4,24 +4,34 @@
 set -eo pipefail
 
 
-# Error handling function.
+# Function for printing error messages and exiting with a specific exit code
+# $1 - The exit code to use when exiting the script
+# $2 - The error message to print
 err() {
-  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  local code="$1"
+  shift
+  echo "[[ERROR]: $(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  exit "$code"
 }
 
 
 # args check
 if [ "$#" -ne 1 ]; then
-  err "Specify a single directory."
-  exit 1
+  err  255 'Specify a single directory.'
+fi
+
+
+# Directory exist check
+if [ ! -d "$1" ]; then
+  err  255 'Directory does not exist.'
 fi
 
 
 # Find only regular files and put in array.
-files=$(find $1 -type f)
+files=( $(find "$1" -type f) )
 
 
 # Then we cut off the paths and extensions.
-for file in $files; do
-  echo ${file%.*}
+for file in "${files[@]}"; do
+  echo "${file%%.*}"
 done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -4,6 +4,7 @@
 set -eo pipefail
 
 
+# Error handling function.
 err() {
   echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
 }


### PR DESCRIPTION
## [Link to the task](https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter2%20-%20bash%20basics/l2/bash%20expansion.md#t4---get-filename-without-the-extension)

Create bash scripts that should use bash shell expansions explained above.
## Task 4 - get filename without the extension
Script should get a folder as an argument and return all files (including in the nested directories) but without the extension

name the file: `chapter2-l2-t4-files-no-extensions.sh`

example of the call:

`./chapter2-l2-t4-files-no-extensions.sh ~/tmp/bazel`
```
/tmp/bazel/tools/objc/dummy
/tmp/bazel/third_party/zlib/zutil
/tmp/bazel/third_party/zlib/uncompr
/tmp/bazel/third_party/zlib/trees
/tmp/bazel/third_party/zlib/test/minigzip
/tmp/bazel/third_party/zlib/test/infcover
/tmp/bazel/third_party/zlib/test/example
/tmp/bazel/third_party/zlib/inftrees
```
## My output:
```
✦12 ➜ ./chapter2-l2-t4-files-no-extensions.sh /opt/Obsidian
/opt/Obsidian/resources/app.asar.unpacked/node_modules/get-fonts/binding
/opt/Obsidian/resources/app.asar.unpacked/node_modules/btime/binding
/opt/Obsidian/resources/app.asar.unpacked/node_modules/vibrancy-win/binding
/opt/Obsidian/resources/obsidian
/opt/Obsidian/resources/app
/opt/Obsidian/libvk_swiftshader
/opt/Obsidian/v8_context_snapshot
/opt/Obsidian/obsidian
/opt/Obsidian/chrome_200_percent
/opt/Obsidian/icudtl
/opt/Obsidian/libvulkan.so
/opt/Obsidian/libGLESv2
/opt/Obsidian/libEGL
...
```