### PR TITLE
 feat: t6 - get only dirs of the files

### DIFF
--- a/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
+++ b/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
@@ -25,7 +25,7 @@ fi
 files=$(find "$1" -type f)
 
 
-
+# Leave only a list of all unique directories, without files
 find "$1" -type f | while read file; do
   echo "${file%/*}"
 done

--- a/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
+++ b/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 # Task 6 - get only dirs of the files
 set -eo pipefail
 
@@ -17,15 +16,11 @@ err() {
 
 # Args check
 if [ "$#" -ne 1 ]; then
-  err 255 'Two arguments are required.'
+  err 255 'Specify a single directory.'
 fi
 
 
-# Find only regular files and put in array
-files=$(find "$1" -type f)
-
-
-# Leave only a list of all unique directories, without files
+# Find only regular files and leave only a unique directories, without filenames.
 find "$1" -type f | while read file; do
   echo "${file%/*}"
 done | sort -u

--- a/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
+++ b/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
@@ -28,4 +28,4 @@ files=$(find "$1" -type f)
 # Leave only a list of all unique directories, without files
 find "$1" -type f | while read file; do
   echo "${file%/*}"
-done
+done | sort -u

--- a/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
+++ b/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
@@ -4,24 +4,28 @@
 set -eo pipefail
 
 
-# Error handling function.
+# Function for printing error messages and exiting with a specific exit code
+# $1 - The exit code to use when exiting the script
+# $2 - The error message to print
 err() {
-  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  local code="$1"
+  shift
+  echo "[[ERROR]: $(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  exit "$code"
 }
 
 
-# args check
+# Args check
 if [ "$#" -ne 1 ]; then
-  err "Specify a single directory."
-  exit 1
+  err 255 'Two arguments are required.'
 fi
 
 
 # Find only regular files and put in array
-files=$(find $1 -type f)
+files=$(find "$1" -type f)
 
 
-# Extract file names and keep only unique directories.
-for file in $files; do
-  echo ${file%/*}
-done | sort | uniq
+
+find "$1" -type f | while read file; do
+  echo "${file%/*}"
+done

--- a/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
+++ b/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
@@ -4,9 +4,15 @@
 set -eo pipefail
 
 
+# Error handling function.
+err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+}
+
+
 # args check
 if [ "$#" -ne 1 ]; then
-  echo "Specify a single directory."
+  err "Specify a single directory."
   exit 1
 fi
 

--- a/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
+++ b/chapter2/tests/t6/chapter2-l2-t6-get-file-unique-dirs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Task 6 - get only dirs of the files
+set -eo pipefail
+
+
+# args check
+if [ "$#" -ne 1 ]; then
+  echo "Specify a single directory."
+  exit 1
+fi
+
+
+# Find only regular files and put in array
+files=$(find $1 -type f)
+
+
+# Extract file names and keep only unique directories.
+for file in $files; do
+  echo ${file%/*}
+done | sort | uniq


### PR DESCRIPTION
## [Link to the task](https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter2%20-%20bash%20basics/l2/bash%20expansion.md#t6---get-only-dirs-of-the-files)

## Task 6 - get only dirs of the files

Script should get a folder as an argument and return a list of unique directories of all files (including in the nested directories). only -f option is allowed for the use of find command, i.e.: find /tmp -type f. Which should find all files in all nested dirs and then process the output by using expansion.

name the file: `chapter2-l2-t6-get-file-unique-dirs.sh`

example of the call:

`./chapter2-l2-t6-get-file-unique-dirs.sh ~/tmp`
```
/tmp/setguid
/tmp/bazel/tools/objc
/tmp/bazel/third_party/zlib
/tmp/bazel/third_party/zlib/test
/tmp/bazel/third_party/zlib
/tmp/bazel/third_party/zlib/examples
/tmp/bazel/third_party/zlib
/tmp/bazel/third_party/zlib/contrib/untgz
/tmp/bazel/third_party/zlib/contrib/testzlib
/tmp/bazel/third_party/zlib/contrib/puff
```
## My output:
```
➜ ./chapter2-l2-t6-get-file-unique-dirs.sh  /opt/Obsidian
/opt/Obsidian
/opt/Obsidian/locales
/opt/Obsidian/resources
/opt/Obsidian/resources/app.asar.unpacked/node_modules/btime
/opt/Obsidian/resources/app.asar.unpacked/node_modules/get-fonts
/opt/Obsidian/resources/app.asar.unpacked/node_modules/vibrancy-win
```