### PR TITLE
feat: t7 - get only the filenames

### DIFF
--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# t7 - get only the filenames
+set -eo pipefail
+
+
+# args check
+if [ "$#" -ne 1 ]; then
+  echo "Specify a single directory."
+  exit 1
+fi
+
+
+# Find only regular files and put in array.
+files=$(find $1 -type f)
+
+
+# We keep only unique files with extensions, without paths.
+for file in $files; do
+  echo ${file##*/}
+done | sort | uniq

--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -4,9 +4,14 @@
 set -eo pipefail
 
 
+# Error handling function.
+err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+}
+
 # args check
 if [ "$#" -ne 1 ]; then
-  echo "Specify a single directory."
+  err "Specify a single directory."
   exit 1
 fi
 

--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 # t7 - get only the filenames
 set -eo pipefail
 
@@ -21,11 +20,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 
-# Find only regular files and put in array.
-files=$(find "$1" -type f)
-
-
-# Leave only unique files, without extensions
+# Find only regular files and leave only unique, with extensions but without the absolute path 
 find "$1" -type f | while read file; do
   echo "${file##*/}"
 done | sort -u

--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -4,23 +4,28 @@
 set -eo pipefail
 
 
-# Error handling function.
+# Function for printing error messages and exiting with a specific exit code
+# $1 - The exit code to use when exiting the script
+# $2 - The error message to print
 err() {
-  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  local code="$1"
+  shift
+  echo "[[ERROR]: $(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  exit "$code"
 }
+
 
 # args check
 if [ "$#" -ne 1 ]; then
-  err "Specify a single directory."
-  exit 1
+  err 255 'Specify a single directory.'
 fi
 
 
 # Find only regular files and put in array.
-files=$(find $1 -type f)
+files=$(find "$1" -type f)
 
 
-# We keep only unique files with extensions, without paths.
-for file in $files; do
-  echo ${file##*/}
-done | sort | uniq
+# Leave only unique files, without extensions
+find "$1" -type f | while read file; do
+  echo "${file##*/}"
+done | sort -u


### PR DESCRIPTION
## [Link to the task](https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter2%20-%20bash%20basics/l2/bash%20expansion.md#t7---get-only-the-filenames)

## Task 7 - get only the filenames

Script should get a folder as an argument and return a list of all unique files with extensions but without the absolute path (including in the nested directories). only -f option is allowed for the use of find command, i.e.: find /tmp -type f. Which should find all files in all nested dirs and then process the output by using expansion.

name the file: `chapter2-l2-t7-get-unique-files.sh`

example of the call:

`chapter2-l2-t7-get-unique-files.sh /tmp/bazel`
```
main.sh.x.c
main.c
dummy.c
zutil.c
uncompr.c
trees.c
minigzip.c
infcover.c
example.c
inftrees.c
```

## My output:
```
✗  ./chapter2-l2-t7-get-unique-files.sh /opt/Obsidian                          
af.pak
am.pak
app.asar
ar.pak
bg.pak
binding.node
bn.pak
ca.pak
...
```