### PR TITLE
feat: t9 - display new tcp listening connections in the range 10000-10100 into terminator zsh

### DIFF
--- a/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
+++ b/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Task 9 - display new tcp listening connections in the range 10000-10100 into terminator zsh
+set -eo pipefail
+
+
+# Set the port range
+readonly PORT_RANGE_START='10000'
+readonly PORT_RANGE_END='10100'
+
+# Scrypt name ~/.zshrc
+SCRIPT_NAME="chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh"
+
+# Scrypt path
+SCRIPT_PATH="$(readlink -f "$0")"
+
+# Config path ~/.zshrc
+ZSHRC_FILE="${HOME}/.zshrc"
+
+
+# Autorun exist check ~/.zshrc
+if ! grep -q "${SCRIPT_NAME}" "${ZSHRC_FILE}"; then
+  cp "${ZSHRC_FILE}" "${ZSHRC_FILE}.backup"
+  # Add in ~/.zshrc scrypt path
+  echo "" >> "${ZSHRC_FILE}"
+  echo "# Scrypt to display new tcp listening connections in the range" >> "${ZSHRC_FILE}"
+  echo "${SCRIPT_PATH}" >> "${ZSHRC_FILE}"
+  echo "" >> "${ZSHRC_FILE}"
+fi
+
+
+# Port range expr
+port_range="sport >= :$PORT_RANGE_START and sport <= :$PORT_RANGE_END"
+
+
+# Check if there are any TCP connections listening on the specified port range
+while :
+do
+  if [[ -z $(ss -tano "${port_range}" | grep -v "State") ]]; then
+    # If there are no listening connections, print a message and wait for 2 seconds
+    echo 'No TCP listening sockets found bound to ports in 10000-10100 range'
+    sleep 2
+  else
+    # If there are listening connections, print their details
+    ss -tano "${port_range}" | awk "{printf \"%-20s %-20s\n\", \$4, \$5}"
+    sleep 1
+    clear
+  fi
+done

--- a/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
+++ b/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
@@ -1,49 +1,77 @@
 #!/bin/bash
-#
 # Task 9 - display new tcp listening connections in the range 10000-10100 into terminator zsh
 set -eo pipefail
 
+# The main function to get tcp connections in port range
+get_tcp() {
+  # Set the port range
+  readonly port_range_start='10000'
+  readonly port_range_end='10100'
+  export port_range="sport >= :$port_range_start and sport <= :$port_range_end"
 
-# Set the port range
-readonly PORT_RANGE_START='10000'
-readonly PORT_RANGE_END='10100'
+  print_no_connections() {
+    echo "No TCP listening sockets found bound to ports in 10000-10100 range"
+    sleep 3
+  }
 
-# Scrypt name ~/.zshrc
-SCRIPT_NAME="chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh"
+  # Function to get the list of TCP connections in port range, without header
+  get_connections() {
+    ss -tan "${port_range}" | awk 'NR>1 {printf "%-20s %-20s\n", $4, $5}'
+  }
 
-# Scrypt path
-SCRIPT_PATH="$(readlink -f "$0")"
+  connections="$(get_connections)"
 
-# Config path ~/.zshrc
-ZSHRC_FILE="${HOME}/.zshrc"
-
-
-# Autorun exist check ~/.zshrc
-if ! grep -q "${SCRIPT_NAME}" "${ZSHRC_FILE}"; then
-  cp "${ZSHRC_FILE}" "${ZSHRC_FILE}.backup"
-  # Add in ~/.zshrc scrypt path
-  echo "" >> "${ZSHRC_FILE}"
-  echo "# Scrypt to display new tcp listening connections in the range" >> "${ZSHRC_FILE}"
-  echo "${SCRIPT_PATH}" >> "${ZSHRC_FILE}"
-  echo "" >> "${ZSHRC_FILE}"
-fi
-
-
-# Port range expr
-port_range="sport >= :$PORT_RANGE_START and sport <= :$PORT_RANGE_END"
-
-
-# Check if there are any TCP connections listening on the specified port range
-while :
-do
-  if [[ -z $(ss -tano "${port_range}" | grep -v "State") ]]; then
-    # If there are no listening connections, print a message and wait for 2 seconds
-    echo 'No TCP listening sockets found bound to ports in 10000-10100 range'
-    sleep 2
+  # If there are no listening connections, print a message, owerwise show connections
+  if [ -z "${connections}" ]; then
+    print_no_connections
   else
-    # If there are listening connections, print their details
-    ss -tano "${port_range}" | awk "{printf \"%-20s %-20s\n\", \$4, \$5}"
-    sleep 1
-    clear
+    echo "Local Address:Port    Peer Address:Port"
+    echo "${connections}"
   fi
-done
+
+  # Loop to append connections
+  while true; do
+    new_connections="$(get_connections)"
+
+    if [ -z "${new_connections}" ]; then
+      print_no_connections
+      connections="${new_connections}"
+    fi
+
+
+    # If there were no connections before but now there are, print the header again
+    if [ -z "${connections}" ] && [ -n "${new_connections}" ]; then
+      echo "Local Address:Port    Peer Address:Port"
+    fi
+
+    # Compare the new list of connections with the old one and print the unique ones in new_connections
+    unique_connections=$(comm -13 <(echo "${connections}" | sort) <(echo "${new_connections}" | sort))
+
+    if [ -n "${unique_connections}" ]; then
+      echo "${unique_connections}"
+    fi
+
+    connections="${new_connections}"
+
+  done
+}
+
+
+while true; do
+    # Retrieve all addresses of Terminator pseudo-interfaces
+    pseudo_addresses=$(for pid in $(pgrep -P $(pgrep terminator)); do
+        readlink /proc/$pid/fd/0
+    done | sort)
+
+    # Use comm to identify new addresses
+    new_addresses=$(comm -13 <(printf '%s\n' "${addresses[@]}" | sort) <(echo "$pseudo_addresses"))
+
+    # Add new unique addresses to the addresses array and invoke the get_tcp function for each of them
+    for address in $new_addresses
+    do
+        addresses+=("$address")
+        get_tcp >> "$address" 2>&1 &
+    done
+
+    sleep 1
+done &

--- a/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
+++ b/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
@@ -40,14 +40,14 @@ get_tcp() {
 
 
     # If there were no connections before but now there are, print the header again
-    if [ -z "${connections}" ] && [ -n "${new_connections}" ]; then
+    if [[ -z "${connections}" ]] && [[ -n "${new_connections}" ]]; then
       echo "Local Address:Port    Peer Address:Port"
     fi
 
     # Compare the new list of connections with the old one and print the unique ones in new_connections
     unique_connections=$(comm -13 <(echo "${connections}" | sort) <(echo "${new_connections}" | sort))
 
-    if [ -n "${unique_connections}" ]; then
+    if [[ -n "${unique_connections}" ]]; then
       echo "${unique_connections}"
     fi
 
@@ -60,7 +60,9 @@ get_tcp() {
 while true; do
     # Retrieve all addresses of Terminator pseudo-interfaces
     pseudo_addresses=$(for pid in $(pgrep -P $(pgrep terminator)); do
-        readlink /proc/$pid/fd/0
+        if [[ "$(readlink /proc/$pid/exe)" =~ "zsh" ]]; then
+          readlink /proc/$pid/fd/0
+        fi
     done | sort)
 
     # Use comm to identify new addresses


### PR DESCRIPTION
## [Link to the task](https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter2%20-%20bash%20basics/l4/sockets.md#t9---display-new-tcp-listening-connections-in-the-range-10000-10100-into-terminator-zsh)

## t9 - display new tcp listening connections in the range 10000-10100 into terminator zsh

The solution should always output in the open terminator console even if you close and reopen the terminator window.

name the file: `chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh`

no args to the shell script. So you run this script. Close the shell/terminator in which you ran this script. Open another terminator/shell (and you don't run another instance of chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh), run new nginx in a desired port range and immediately get that single line displayed in that new terminator/shell window.