### PR TITLE
feat: t14 - compile distroless python3 oom container

### DIFF
--- a/chapter2/tests/t14/Dockerfile
+++ b/chapter2/tests/t14/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.10.11-slim-buster AS builder
+
+WORKDIR /app
+COPY memory.py requirements.txt ./
+RUN apt-get update && apt-get install -y gcc=4:8.3.0-1 python3-dev=3.7.3-1 musl-dev=1.1.21-2 --no-install-recommends
+RUN pip install --no-cache-dir -r requirements.txt --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+FROM gcr.io/distroless/python3@sha256:c472650ee9b43ce1bb7efa2960c95c046fa44f7258ae22f9ceb3d3f49f26d010 AS runtime
+
+COPY --from=builder /app /app
+COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+ENV PYTHONPATH=/usr/local/lib/python3.10/site-packages
+CMD ["/app/memory.py"]

--- a/chapter2/tests/t14/Dockerfile
+++ b/chapter2/tests/t14/Dockerfile
@@ -1,15 +1,20 @@
-FROM python:3.10.11-slim-buster AS builder
+ARG PYTHON_VERSION=3.10.11-slim-buster
+ARG DISTROLESS_VERSION=gcr.io/distroless/python3@sha256:c472650ee9b43ce1bb7efa2960c95c046fa44f7258ae22f9ceb3d3f49f26d010
+
+FROM python:"${PYTHON_VERSION}" AS builder
 
 WORKDIR /app
 COPY memory.py requirements.txt ./
-RUN apt-get update && apt-get install -y gcc=4:8.3.0-1 python3-dev=3.7.3-1 musl-dev=1.1.21-2 --no-install-recommends
-RUN pip install --no-cache-dir -r requirements.txt --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+RUN apt-get update \
+    && apt-get install -y gcc=4:8.3.0-1 python3-dev=3.7.3-1 musl-dev=1.1.21-2 --no-install-recommends
 
-FROM gcr.io/distroless/python3@sha256:c472650ee9b43ce1bb7efa2960c95c046fa44f7258ae22f9ceb3d3f49f26d010 AS runtime
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt 
+
+FROM "${DISTROLESS_VERSION}" AS runtime
 
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 ENV PYTHONPATH=/usr/local/lib/python3.10/site-packages
-CMD ["/app/memory.py"]
+ENTRYPOINT [ "python", "/app/memory.py" ]

--- a/chapter2/tests/t14/Makefile
+++ b/chapter2/tests/t14/Makefile
@@ -1,0 +1,15 @@
+IMAGE_NAME := oom:v1
+CONTAINER_NAME := oom_v1
+DEFAULT_LIMIT := 100m
+
+build:
+	docker build -t $(IMAGE_NAME) .
+
+run:
+	@if [ -z "$(limit)" ]; then \
+		docker run --rm --name $(CONTAINER_NAME) -m $(DEFAULT_LIMIT) $(IMAGE_NAME); \
+	else \
+		docker run --name $(CONTAINER_NAME) -m $(limit) $(IMAGE_NAME) || (docker inspect $(CONTAINER_NAME) --format='{{.State}}' && exit 1); \
+	fi
+
+.PHONY: build run

--- a/chapter2/tests/t14/memory.py
+++ b/chapter2/tests/t14/memory.py
@@ -1,0 +1,12 @@
+import array
+from memory_profiler import memory_usage
+
+
+def allocate(size):
+    some_var = array.array("l", range(size))
+
+
+usage = memory_usage((allocate, (int(1e7),)))
+peak = max(usage)
+print(f"Usage over time: {usage}")
+print(f"Peak usage: {peak}")

--- a/chapter2/tests/t14/readme.md
+++ b/chapter2/tests/t14/readme.md
@@ -1,0 +1,17 @@
+## Task 14 - compile distroless python3 OOM container
+[link to task:](https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter4%20-%20containers/l1/introduction.md#compile-distroless-python3-oom-container)
+### What you will need to do:
+- `make build`
+- `make run` to run conteiner with default memory limit of `100m`
+- `make run limit=30m` start the docker container with the specified memory limit
+
+### My output:
+```
+➜ make run
+Usage over time: [20.46484375, 20.57421875, 28.25390625, 36.296875, 41.96875, 47.60546875, 55.59765625, 63.70703125, 71.69921875, 79.69140625, 87.94140625, 95.93359375, 20.57421875]
+Peak usage: 95.93359375
+
+➜ make run limit=30m
+{exited false false false true false 0 137  2023-04-25T10:23:53.339562278Z 2023-04-25T10:23:54.050109556Z <nil>}
+make: *** [Makefile:8: run] Error 1
+```

--- a/chapter2/tests/t14/requirements.txt
+++ b/chapter2/tests/t14/requirements.txt
@@ -1,0 +1,1 @@
+memory_profiler==0.61.0


### PR DESCRIPTION
## [Link to the task](https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter4%20-%20containers/l1/introduction.md#compile-distroless-python3-oom-container)

## Task 14 - compile distroless python3 oom container

Compile container using distroless base python3 image `https://github.com/GoogleContainerTools/distroless`

See python files in `testtask` folder.

### What you will need to do:

- setup pre-commit in the folder to run https://github.com/hadolint/hadolint checks against any Dockerfiles
    - don't open any PR if your Dockerfile does not pass validation from the linter.
- provide README.md with instructions how to run/test your work
- create Makefile with the following targets:
    - build
    - run
        - run target should accept parameter limit that will set the desired max memory limit for the running docker container
        - if such parameter is not set, a default value of 100m should be used
- make run should start the docker container and output content similar to
```
    Usage over time: [20.67578125, 20.67578125, 35.30078125, 50.17578125, 64.80078125, 79.55078125, 94.30078125, 20.734375]
    Peak usage: 94.30078125
```
- make run with optional argument for memory set at 30m should understand that container exited by error and in this case output the following line
```
    {exited false false false true false 0 137  2023-04-17T00:50:11.053754525Z 2023-04-17T00:50:13.721847306Z <nil>}

    which is content of the docker State value.
```

### My output:
```
➜ make run
Usage over time: [20.46484375, 20.57421875, 28.25390625, 36.296875, 41.96875, 47.60546875, 55.59765625, 63.70703125, 71.69921875, 79.69140625, 87.94140625, 95.93359375, 20.57421875]
Peak usage: 95.93359375

➜ make run limit=30m
{exited false false false true false 0 137  2023-04-25T10:23:53.339562278Z 2023-04-25T10:23:54.050109556Z <nil>}
make: *** [Makefile:8: run] Error 1
```
